### PR TITLE
修复使用443端口的时，构造的仓库地址错误, 以http的格式无法检出http://host:443

### DIFF
--- a/02.php/app/service/Svnrep.php
+++ b/02.php/app/service/Svnrep.php
@@ -68,13 +68,23 @@ class Svnrep extends Base
                 'prefix' => $checkoutHost
             ]);
         } else {
-            $checkoutHost = ($this->dockerHttpPort == 80 ? $this->dockerHost : $this->dockerHost . ':' . $this->dockerHttpPort) . ($this->httpPrefix == '/' ? '' : $this->httpPrefix);
+            $checkoutHost = $this->dockerHost;
+
+            if ($this->dockerHttpPort != 80 && $this->dockerHttpPort != 443) {
+                $checkoutHost .= ':' . $this->dockerHttpPort;
+            }
+
+            if ($this->httpPrefix != '/') {
+                $checkoutHost .= $this->httpPrefix;
+            }
+
+            $protocal = $this->dockerHttpPort == 443 ? 'https://' : 'http://';
 
             return message(200, 1, '成功', [
-                'protocal' => 'http://',
+                'protocal' => $protocal,
                 'prefix' => $checkoutHost
             ]);
-        }
+       }
     }
 
     /**


### PR DESCRIPTION
修复使用443端口的时，构造的仓库地址错误, 以http的格式无法检出http://host:443